### PR TITLE
Uploaded cookie check for logins

### DIFF
--- a/slack_backup/download.py
+++ b/slack_backup/download.py
@@ -175,8 +175,7 @@ class Download(object):
                                  'password': self.password,
                                  'signin': 1})
         self.cookies = requests.utils.dict_from_cookiejar(self.session.cookies)
-        if not ('a' in self.cookies and 'b' in self.cookies and
-                ('a-' + self.cookies['a']) in self.cookies):
+        if not ('d' in self.cookies and 'd-s' in self.cookies):
             logging.error('Failed to login into Slack app')
         else:
             self._authorized = True


### PR DESCRIPTION
Logins were failing, looks like the auth cookies have changed a bit? When logging in, it looks like a failed login generates a 'b' (browser) cookie regardless so that shouldn't be there. And the actual tokens have moved from 'a' cookies to 'd' and 'd-s' cookies.